### PR TITLE
Spinner fix

### DIFF
--- a/Classes/UIScrollView+BottomRefreshControl.m
+++ b/Classes/UIScrollView+BottomRefreshControl.m
@@ -166,7 +166,7 @@ const CGFloat kMinRefershTime = 0.5;
 
     CGFloat offset = (contentOffset.y + contentInset.top + height) - MAX((self.contentSize.height + contentInset.bottom + contentInset.top), height);
     
-    if (offset > 0)
+    if (offset >= 0)
         [self handleBottomBounceOffset:offset];
     else
         self.brc_context.refreshed = NO;


### PR DESCRIPTION
This will fix the issues we have with the refresh control remaining visible in some scenarios.
When the scrolling of the table view is interrupted (i.e. the keyboard is dismissed by the drag), this offset will jump to 0, so it needs to be handled in order to hide the refresh control.
